### PR TITLE
Spielbrett: ZielFelder Fix 2

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/at/se2/gruppe3/menschrgeredichnicht/BoardActivity.java
+++ b/app/src/main/java/at/se2/gruppe3/menschrgeredichnicht/BoardActivity.java
@@ -130,7 +130,9 @@ public class BoardActivity extends Activity implements BoardView.OnFeldClickedLi
                 break;
             case 2:
                 if(KegelHighlighted!=null){
-                    moveKegel(KegelHighlighted,state,position);
+                    if(KegelHighlighted.getPlayer() == player) {
+                        moveKegel(KegelHighlighted, state, position);
+                    }
                 }else{
                     KegelHighlighted = ZielFelder[player][position];
                     BView.highlightKegel(KegelHighlighted);
@@ -153,6 +155,9 @@ public class BoardActivity extends Activity implements BoardView.OnFeldClickedLi
                 HauptFelder[position] = new Kegel(k.getPlayer(),state,position);
                 break;
             case 2:
+                if(ZielFelder[k.getPlayer()][position] != null){
+                    break;
+                }
                 ZielFelder[k.getPlayer()][position] = new Kegel(k.getPlayer(),state,position);
                 break;
         }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Wenn Kegel in fremde Zielfelder bewegt wurden, wurde der Kegel gelöscht. 
Mit diesem Fix von Christian behoben.
